### PR TITLE
Updated to work on 0.17.2

### DIFF
--- a/control/maze-control.lua
+++ b/control/maze-control.lua
@@ -341,57 +341,15 @@ function ribbonMazeGenerateResources(config, modSurfaceInfo, surface, chunkPosit
 
             surface.set_tiles(updatedTiles)
 
-            local mangroveStartX
-            local mangroveStartY
-            local mangroveEndX
-            local mangroveEndY
-
-            if not Maze.wallTileAt(modSurfaceInfo.maze, mazePosition.x, mazePosition.y+1) then
-                if modSurfaceInfo.mazeInfo.swapXY then
-                else
-                    mangroveStartX = chunkPosition.x + 1
-                    mangroveStartY = chunkPosition.y
-                    mangroveEndX = chunkPosition.x + 30
-                    mangroveEndY = chunkPosition.y + 1
-                end
-            elseif not Maze.wallTileAt(modSurfaceInfo.maze, mazePosition.x, mazePosition.y-1) and mazePosition.y > 1 then
-                if modSurfaceInfo.mazeInfo.swapXY then
-                else
-                    mangroveStartX = chunkPosition.x + 1
-                    mangroveStartY = chunkPosition.y + 30
-                    mangroveEndX = chunkPosition.x + 30
-                    mangroveEndY = chunkPosition.y + 31
-                end
-            elseif not Maze.wallTileAt(modSurfaceInfo.maze, mazePosition.x+1, mazePosition.y) then
-                if modSurfaceInfo.mazeInfo.swapXY then
-                else
-                    mangroveStartY = chunkPosition.y + 1
-                    mangroveStartX = chunkPosition.x + 30
-                    mangroveEndY = chunkPosition.y + 30
-                    mangroveEndX = chunkPosition.x + 31
-                end
-            elseif not Maze.wallTileAt(modSurfaceInfo.maze, mazePosition.x-1, mazePosition.y) then
-                if modSurfaceInfo.mazeInfo.swapXY then
-                else
-                    mangroveStartY = chunkPosition.y + 1
-                    mangroveStartX = chunkPosition.x
-                    mangroveEndY = chunkPosition.y + 30
-                    mangroveEndX = chunkPosition.x + 1
-                end
-            end
-
             -- the mangroves
-            if mangroveStartX then
-
-                for tileY = mangroveStartY, mangroveEndY do
-                    for tileX = mangroveStartX, mangroveEndX do
-                        local randMangrove = Cmwc.randFraction(resource.rng)
-                        if randMangrove <= config.mangroveDensity then
-                            if config.mangroveGreenRawRatio == 1 or randMangrove <= (config.mangroveDensity * config.mangroveGreenRawRatio) then
-                                surface.create_entity{name="mangrove-avicennia", position={tileX,tileY}}
-                            else
-                                surface.create_entity{name="mangrove-bruguiera", position={tileX,tileY}}
-                            end
+            for tileY = chunkPosition.y, chunkPosition.y+31 do
+                for tileX = chunkPosition.x, chunkPosition.x+31 do
+                    local randMangrove = Cmwc.randFraction(resource.rng)
+                    if randMangrove <= config.mangroveDensity then
+                        if config.mangroveGreenRawRatio == 1 or randMangrove <= (config.mangroveDensity * config.mangroveGreenRawRatio) then
+                            surface.create_entity{name="mangrove-avicennia", position={tileX,tileY}}
+                        else
+                            surface.create_entity{name="mangrove-bruguiera", position={tileX,tileY}}
                         end
                     end
                 end
@@ -619,11 +577,7 @@ function ribbonMazeChunkGeneratedEventHandler(event)
                 isFirstMazeWaterRowEdge(config, modSurfaceInfo, chunkTilePosition) and
                 config.terraformingPrototypesEnabled and
                 modSurfaceInfo.firstMazeRowMangroveRng[x] then
-
-            local resourceAbove = resourceAt(config, surface, modSurfaceInfo, {x=x, y=y+1})
-            if resourceAbove == nil or resourceAbove.resourceName ~= "water_" then
-                generateMangroves(modSurfaceInfo, surface, chunkTilePosition, modSurfaceInfo.firstMazeRowMangroveRng[x], config)
-            end
+            generateMangroves(modSurfaceInfo, surface, chunkTilePosition, modSurfaceInfo.firstMazeRowMangroveRng[x], config)
         elseif tileName == config.mazeWallTile then
             for tileX = chunkTilePosition.x+1, chunkTilePosition.x+29,4 do
                 for tileY = chunkTilePosition.y+1, chunkTilePosition.y+29,4 do

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "RibbonMaze",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "title": "Ribbon Maze",
   "author": "H8UL",
   "contact": "h8ul.mods@gmail.com",
   "homepage": "https://mods.factorio.com/user/h8ul",
-  "factorio_version": "0.16",
-  "dependencies": ["base >= 0.16.51"],
+  "factorio_version": "0.17",
+  "dependencies": ["base >= 0.17.01"],
   "description": "The maze itself is destined to be automated."
 }

--- a/prototypes/achievements.lua
+++ b/prototypes/achievements.lua
@@ -44,7 +44,7 @@ data:extend{
         type = "produce-per-hour-achievement",
         name = "feller-buncher",
         order = "aa[production]-b[feller-buncher]",
-        item_product = "raw-wood",
+        item_product = "wood",
         amount = 1000,
         icons = {
             {

--- a/prototypes/entity/maze-terraforming-result.lua
+++ b/prototypes/entity/maze-terraforming-result.lua
@@ -24,12 +24,12 @@ data:extend{
     {
         type = "simple-entity",
         name = "maze-terraforming-result",
-        icon = "__base__/graphics/icons/stone-wall.png",
+        icon = "__base__/graphics/icons/wall.png",
         picture = {
             filename = "__base__/graphics/entity/pipe/hr-pipe-cross.png",
             priority = "extra-high",
-            width = 0,
-            height = 0,
+            width = 128,
+            height = 128,
         },
         icon_size = 32,
         collision_mask = {},

--- a/prototypes/entity/maze-terraforming-target.lua
+++ b/prototypes/entity/maze-terraforming-target.lua
@@ -24,12 +24,12 @@ data:extend{
     {
         type = "simple-entity-with-force",
         name = "maze-terraforming-target",
-        icon = "__base__/graphics/icons/stone-wall.png",
+        icon = "__base__/graphics/icons/wall.png",
         picture = {
             filename = "__base__/graphics/entity/pipe/hr-pipe-cross.png",
             priority = "extra-high",
-            width = 0,
-            height = 0,
+            width = 128,
+            height = 128,
         },
         icon_size = 32,
         collision_mask = {"object-layer"},

--- a/prototypes/entity/maze-terraforming-target.lua
+++ b/prototypes/entity/maze-terraforming-target.lua
@@ -28,8 +28,8 @@ data:extend{
         picture = {
             filename = "__base__/graphics/entity/pipe/hr-pipe-cross.png",
             priority = "extra-high",
-            width = 128,
-            height = 128,
+            width = 1,
+            height = 1,
         },
         icon_size = 32,
         collision_mask = {"object-layer"},

--- a/prototypes/item/compost.lua
+++ b/prototypes/item/compost.lua
@@ -25,7 +25,7 @@ data:extend{{
     name = "compost",
     icon = "__RibbonMaze__/graphics/icons/compost.png",
     icon_size = 32,
-    flags = {"goes-to-main-inventory"},
+    flags = {},
     subgroup = "intermediate-product",
     order = "o[compost]",
     stack_size = 500

--- a/prototypes/item/composting-browns.lua
+++ b/prototypes/item/composting-browns.lua
@@ -25,7 +25,7 @@ data:extend{{
     name = "composting-browns",
     icon = "__RibbonMaze__/graphics/icons/composting-browns.png",
     icon_size = 32,
-    flags = {"goes-to-main-inventory"},
+    flags = {},
     subgroup = "intermediate-product",
     order = "o[compost]",
     stack_size = 200

--- a/prototypes/item/composting-greens.lua
+++ b/prototypes/item/composting-greens.lua
@@ -25,7 +25,7 @@ data:extend{{
     name = "composting-greens",
     icon = "__RibbonMaze__/graphics/icons/composting-greens.png",
     icon_size = 32,
-    flags = {"goes-to-main-inventory"},
+    flags = {},
     subgroup = "intermediate-product",
     order = "o[compost]",
     stack_size = 200

--- a/prototypes/item/geocomposite.lua
+++ b/prototypes/item/geocomposite.lua
@@ -34,7 +34,7 @@ data:extend{{
             tint = {r=0, g=0, b=0, a=1},
         }
     },
-    flags = {"goes-to-main-inventory"},
+    flags = {},
     subgroup = "intermediate-product",
     order = "o[geocomposite]",
     stack_size = 200

--- a/prototypes/item/green-wood.lua
+++ b/prototypes/item/green-wood.lua
@@ -24,11 +24,11 @@ data:extend{{
     type = "item",
     name = "green-wood",
     icons = {{
-        icon = "__base__/graphics/icons/raw-wood.png",
+        icon = "__base__/graphics/icons/wood.png",
         icon_size = 32,
         tint = {r=0.41, g=0.8, b=0.41, a=1.0},
     }},
-    flags = {"goes-to-main-inventory"},
+    flags = {},
     order = "a[green-wood]",
     stack_size = 50,
     subgroup = "raw-resource",

--- a/prototypes/item/mangrove-harvester.lua
+++ b/prototypes/item/mangrove-harvester.lua
@@ -30,13 +30,13 @@ data:extend {{
             icon_size = 32,
         },
         {
-            icon = "__base__/graphics/icons/raw-wood.png",
+            icon = "__base__/graphics/icons/wood.png",
             shift = {3, 3},
             icon_size = 32,
             tint = {r=0.41, g=0.8, b=0.41, a=0.5},
         }
     },
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "extraction-machine",
     order = "a[items]-b[mangrove-harvester]",
     place_result = "mangrove-harvester",

--- a/prototypes/recipe/composting-shredding.lua
+++ b/prototypes/recipe/composting-shredding.lua
@@ -29,7 +29,7 @@ data:extend {
         always_show_made_in = true,
         ingredients =
         {
-            {"raw-wood", 10},
+            {"wood", 10},
         },
         results = {
             {type="item", name="composting-greens", amount=1},
@@ -39,7 +39,7 @@ data:extend {
         subgroup = "intermediate-product",
         icons = {
             {
-                icon = "__base__/graphics/icons/raw-wood.png",
+                icon = "__base__/graphics/icons/wood.png",
                 icon_size = 32,
             },
             {
@@ -68,7 +68,7 @@ data:extend {
         subgroup = "intermediate-product",
         icons = {
             {
-                icon = "__base__/graphics/icons/raw-wood.png",
+                icon = "__base__/graphics/icons/wood.png",
                 icon_size = 32,
                 tint = {r=0.41, g=0.8, b=0.41, a=1.0},
             },

--- a/prototypes/recipe/wood-kiln-drying.lua
+++ b/prototypes/recipe/wood-kiln-drying.lua
@@ -29,19 +29,19 @@ data:extend {{
     ingredients = {
         {"green-wood", 1}
     },
-    result= "raw-wood",
+    result= "wood",
     subgroup="raw-material",
     always_show_made_in = true,
     main_product = "",
     icons = {
         {
-            icon = "__base__/graphics/icons/raw-wood.png",
+            icon = "__base__/graphics/icons/wood.png",
             icon_size = 32,
             shift = {-3, -3},
             tint = {r=0.41, g=0.8, b=0.41, a=1.0},
         },
         {
-            icon = "__base__/graphics/icons/raw-wood.png",
+            icon = "__base__/graphics/icons/wood.png",
             icon_size = 32,
             shift = {3, 3},
         }

--- a/prototypes/resource/mangrove.lua
+++ b/prototypes/resource/mangrove.lua
@@ -84,7 +84,7 @@ data:extend {{
     tree_removal_max_distance = 1,
     minable = {
         mining_time = 10,
-        result = "raw-wood",
+        result = "wood",
         count = 1,
         mining_particle = "wooden-particle",
         hardness = 0.5
@@ -94,8 +94,8 @@ data:extend {{
         sheet = {
             filename = "__base__/graphics/entity/tree/green-coral/green-coral-06.png",
             priority = "extra-high",
-            width = 77,
-            height = 97,
+            width = 67,
+            height = 71,
             frame_count = 1,
             variation_count = 1
         }

--- a/prototypes/technology/in-vessel-composting.lua
+++ b/prototypes/technology/in-vessel-composting.lua
@@ -56,9 +56,9 @@ data:extend{{
     unit =
     {
         ingredients = {
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
-            {"science-pack-3", 1}
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 1}
         },
         time = 30,
         count = 250

--- a/prototypes/technology/mangrove-harvesting.lua
+++ b/prototypes/technology/mangrove-harvesting.lua
@@ -46,9 +46,9 @@ data:extend{{
         ingredients =
         {
             {"production-science-pack", 1},
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
-            {"science-pack-3", 1}
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 1}
         },
         time = 60
     },

--- a/prototypes/technology/maze-terraforming.lua
+++ b/prototypes/technology/maze-terraforming.lua
@@ -49,11 +49,11 @@ data:extend{{
     {
         ingredients =
         {
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
-            {"science-pack-3", 1},
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 1},
             {"production-science-pack", 1},
-            {"high-tech-science-pack", 1}
+            {"utility-science-pack", 1}
         },
         time = 30,
         count = 2000

--- a/prototypes/technology/oil-scanning.lua
+++ b/prototypes/technology/oil-scanning.lua
@@ -45,8 +45,8 @@ data:extend{{
         count = 250,
         ingredients =
         {
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
         },
         time = 30
     },

--- a/prototypes/technology/update-landfill.lua
+++ b/prototypes/technology/update-landfill.lua
@@ -27,9 +27,9 @@ landfillTech.prerequisites = {"nuclear-power", "in-vessel-composting"}
 landfillTech.unit = {
     ingredients = {
         {"production-science-pack", 1},
-        {"science-pack-1", 1},
-        {"science-pack-2", 1},
-        {"science-pack-3", 1}
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1}
     },
     time = 30,
     count = 250

--- a/prototypes/technology/uranium-scanning.lua
+++ b/prototypes/technology/uranium-scanning.lua
@@ -45,9 +45,9 @@ data:extend{{
         count = 1000,
         ingredients =
         {
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
-            {"science-pack-3", 1},
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 1},
         },
         time = 30
     },

--- a/prototypes/technology/wood-kiln-drying.lua
+++ b/prototypes/technology/wood-kiln-drying.lua
@@ -37,8 +37,8 @@ data:extend{{
         count = 50,
         ingredients =
         {
-            {"science-pack-1", 1},
-            {"science-pack-2", 1},
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
         },
         time = 30
     },


### PR DESCRIPTION
All entries of raw-wood -> wood to reflect changes in base.
All entries of stone-wall -> wall to reflect changes in base.
All sprites updated to the correct sprite named png file.
Coral06 sprite updated with correct sizes of 67x71.
Player inventory fundamentally changed, so old tags involving it are removed.

This should get you a headstart on 0.17 changes. Let me know if I messed something up.